### PR TITLE
Replaced the component callback to a connect call to free up comp init.

### DIFF
--- a/comp.go
+++ b/comp.go
@@ -11,7 +11,7 @@ type StoreComponent interface {
 	Connect(store Store)
 }
 
-// storeComponent wraps a component to add store pubsub logic.
+// storeComponent embeds a component to add store pubsub logic.
 // Also, StoreComponent is embedded to preserve component behavior.
 type storeComponent struct {
 	StoreComponent

--- a/example/main.go
+++ b/example/main.go
@@ -6,12 +6,12 @@ import (
 	"github.com/gopherjs/vecty/elem"
 	"github.com/gopherjs/vecty/event"
 	"github.com/marwan-at-work/vstore"
-	"github.com/marwan-at-work/vstore/example/store"
+	number "github.com/marwan-at-work/vstore/example/store"
 )
 
 func main() {
 	vecty.RenderBody(&body{
-		store: vstore.New(&store.State{}),
+		store: vstore.New(&number.State{}),
 	})
 }
 
@@ -28,7 +28,8 @@ func (b *body) Render() *vecty.HTML {
 
 type mainComp struct {
 	vecty.Core
-	store vstore.Store
+	Dispatch func(action interface{})
+	Number   int
 }
 
 // NewMainComp is the mainComp constructor
@@ -36,15 +37,17 @@ func NewMainComp() vstore.StoreComponent {
 	return &mainComp{}
 }
 
-func (comp *mainComp) Connect(store vstore.Store) {
-	comp.store = store
+func (m *mainComp) Connect(store vstore.Store) {
+	m.Dispatch = store.Dispatch
+
+	state := store.State().(*number.State)
+	m.Number = state.Number
 }
 
 func (m *mainComp) Render() *vecty.HTML {
-	state := m.store.State().(*store.State)
 	return elem.Div(
 		elem.Div(
-			vecty.Text(fmt.Sprint(state.Number)),
+			vecty.Text(fmt.Sprint(m.Number)),
 		),
 		elem.Button(
 			vecty.Text("inc"),
@@ -62,9 +65,9 @@ func (m *mainComp) Render() *vecty.HTML {
 }
 
 func (m *mainComp) onDec(e *vecty.Event) {
-	m.store.Dispatch(store.Decrement{})
+	m.Dispatch(number.Decrement{})
 }
 
 func (m *mainComp) onInc(e *vecty.Event) {
-	m.store.Dispatch(store.Increment{})
+	m.Dispatch(number.Increment{})
 }

--- a/example/main.go
+++ b/example/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"github.com/cathalgarvey/fmtless"
-
 	"github.com/gopherjs/vecty"
 	"github.com/gopherjs/vecty/elem"
 	"github.com/gopherjs/vecty/event"
@@ -12,41 +11,40 @@ import (
 
 func main() {
 	vecty.RenderBody(&body{
-		store: vstore.CreateStore(&store.State{}),
+		store: vstore.New(&store.State{}),
 	})
 }
 
 type body struct {
 	vecty.Core
-	store *vstore.Store
+	store vstore.Store
 }
 
 func (b *body) Render() *vecty.HTML {
 	return elem.Body(
-		b.store.NewComponent(NewMainComp),
+		b.store.Connect(NewMainComp()),
 	)
 }
 
 type mainComp struct {
 	vecty.Core
-	Number   int `vecty:"prop"`
-	Dispatch func(action interface{})
+	store vstore.Store
 }
 
 // NewMainComp is the mainComp constructor
-func NewMainComp(s *vstore.Store) vecty.Component {
-	state := s.GetState().(*store.State)
+func NewMainComp() vstore.StoreComponent {
+	return &mainComp{}
+}
 
-	return &mainComp{
-		Number:   state.Number,
-		Dispatch: s.Dispatch,
-	}
+func (comp *mainComp) Connect(store vstore.Store) {
+	comp.store = store
 }
 
 func (m *mainComp) Render() *vecty.HTML {
+	state := m.store.State().(*store.State)
 	return elem.Div(
 		elem.Div(
-			vecty.Text(fmt.Sprint(m.Number)),
+			vecty.Text(fmt.Sprint(state.Number)),
 		),
 		elem.Button(
 			vecty.Text("inc"),
@@ -64,9 +62,9 @@ func (m *mainComp) Render() *vecty.HTML {
 }
 
 func (m *mainComp) onDec(e *vecty.Event) {
-	m.Dispatch(store.Decrement{})
+	m.store.Dispatch(store.Decrement{})
 }
 
 func (m *mainComp) onInc(e *vecty.Event) {
-	m.Dispatch(store.Increment{})
+	m.store.Dispatch(store.Increment{})
 }

--- a/store.go
+++ b/store.go
@@ -1,51 +1,70 @@
 package vstore
 
-// Store is the main redux-like store. Use it to access the State properties
-// through the ComponentConstructor.
-type Store struct {
-	r    Reducer
-	mws  []Middleware
-	subs map[*SubFunc]bool
+import (
+	"github.com/gopherjs/vecty"
+	"sync"
+)
+
+// store is the main redux-like store. Use it to access the State properties.
+type Store interface {
+	Connect(comp StoreComponent) StoreComponent
+	Dispatch(action interface{})
+	State() interface{}
 }
 
-// SubFunc is a subscription callback.
-type SubFunc func(s *Store)
+// store satisfies Store.
+type store struct {
+	r   Reducer
+	mws []Middleware
+
+	mtx   sync.RWMutex
+	comps map[*storeComponent]bool
+}
 
 // Middleware is a simple middleware that gets called before any Reduce calls.
 type Middleware func(action interface{})
 
-// CreateStore returns a store that you can make global dispatches to in order
+// New returns a store that you can make global dispatches to in order
 // to update the passed global state.
-func CreateStore(r Reducer, mws ...Middleware) *Store {
-	s := Store{r: r, mws: mws, subs: map[*SubFunc]bool{}}
-
-	return &s
+func New(r Reducer, mws ...Middleware) Store {
+	return &store{r: r, mws: mws, comps: map[*storeComponent]bool{}}
 }
 
 // Dispatch takes an action and passes it to all middlewares and the Reduce function.
-// It also calls any subscription functions if exist.
-func (s *Store) Dispatch(action interface{}) {
+// NOTE: vecty.Rerender is called in a goroutine for each subscribed component.
+func (s *store) Dispatch(action interface{}) {
 	for _, m := range s.mws {
 		m(action)
 	}
 
 	s.r.Reduce(action)
 
-	for sub := range s.subs {
-		(*sub)(s)
+	s.mtx.RLock()
+	defer s.mtx.RUnlock()
+
+	for comp := range s.comps {
+		comp := comp
+		go vecty.Rerender(comp)
 	}
 }
 
-// Subscribe subscribes a callback to any store updates.
-func (s *Store) Subscribe(callback SubFunc) func() {
-	s.subs[&callback] = true
-
-	return func() {
-		delete(s.subs, &callback)
-	}
-}
-
-// GetState returns global state.
-func (s *Store) GetState() interface{} {
+// State returns global state.
+func (s *store) State() interface{} {
 	return s.r
+}
+
+// sub subscribes a component to any store updates.
+func (s *store) sub(comp *storeComponent) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	s.comps[comp] = true
+}
+
+// unsub unsubscribes a component to any store updates.
+func (s *store) unsub(comp *storeComponent) {
+	s.mtx.Lock()
+	defer s.mtx.Unlock()
+
+	delete(s.comps, comp)
 }


### PR DESCRIPTION
Replaced the component callback to a connect call to free up component initialization.

Simplified components by embedding components which preserves component behavior.
Added read and write locking to the subscription map usage.
Chose Go idiomatic renaming and added interfaces.


I'm going to explain some changes I've made beyond the simplified commit message.

1. Replaced the component callback to a connect call to free up component initialization.
This was to remove the limitation of the component initialization only accepting a store as an parameter. I added a connect method which components pass access to the store. Therefore, components can be constructed however they want, with whatever passed down to them.

2. Simplified components by embedding components which preserves component behavior.
I simply changed composition to embedding to allow components to continue to satisfy the behavior they choose to, so that vstore usage does not hinder vecty usage.

3. Added read and write locking to the subscription map usage.
This is to protect vstore from race conditions against pubsub logic.

4. Chose Go idiomatic renaming and added interfaces.
This is just to try and be more Go spirited and break away from the JS world. I do not feel strongly about this change.

Additional comments.

1. I let all subscribed components be rerendered if the state changes. This was easy to do after using the StoreComponent interface and it relieves the user from thinking about rerendering while using vstore for state management.

2. I changed the examples state and dispatch callback fields to be the store, this is just preference, I generally stay away from function callbacks if it's trivial to use the behavior when needed, same with state. I do not feel strongly about this change.

3. I changed all the structs to unexpected and created interfaces to export, this is just to make both the users and developers more aware of the API vstore is providing for users, it can also ease unit testing if they satisfy the interfaces. I do not feel strongly about this change.
